### PR TITLE
fix: backlight never turns off after timeout

### DIFF
--- a/lib/Power/Power.cpp
+++ b/lib/Power/Power.cpp
@@ -181,6 +181,11 @@ bool pwr::setPowerRail(status_type type, int GPIO) {
 bool pwr::setScreenBrightness(int brightness) {
 
 	// Convert brightness from 0-5 to 0-255 with a min/max setting
+	if (brightness == 0) {
+		ledcWrite(gpio::pwm_screen_channel, 0);
+		return true;
+	}
+
 	brightness = (brightness * 50) + 5;
 
 	if(brightness < 25){


### PR DESCRIPTION
## Root cause

`pwr::setScreenBrightness(0)` in `lib/Power/Power.cpp` war dafür gedacht, das Backlight komplett auszuschalten. Die Umrechnungsformel `(brightness * 50) + 5` wandelte `0` jedoch in `5` um, das dann von der Min-Clamp auf `25` erhöht wurde. Der PWM-Kanal erhielt also nie `0` — das Backlight blieb permanent an.

## Fix

Early-return für `brightness == 0` hinzugefügt, der direkt `0` in den PWM-Kanal schreibt und die Skalierungs-/Clamp-Logik überspringt.

## Test plan
- [ ] Firmware flashen und Backlight-Timeout konfigurieren (z.B. 1 Minute)
- [ ] Prüfen, dass das Backlight nach dem Timeout ausgeht
- [ ] Prüfen, dass das Backlight wieder angeht wenn eine Taste gedrückt / Seite gewechselt wird

🤖 Generated with [Claude Code](https://claude.com/claude-code)